### PR TITLE
accept code ref for content_type attribute

### DIFF
--- a/lib/Plack/Middleware/Expires.pm
+++ b/lib/Plack/Middleware/Expires.pm
@@ -91,9 +91,13 @@ sub call {
         return if ! defined $type;
         my $type_check;
         for ( @type_match ) {
-            if ( ref $_ && ref $_ eq 'Regexp' ) {
-                if ( $type =~ m!$_! ) {
+            if (my $ref = ref $_) {
+                if ($ref eq 'Regexp' && $type =~ m!$_!) {
                     $type_check = 1;
+                    last;
+                }
+                elsif ($ref eq 'CODE') {
+                    $type_check = $_->($env);
                     last;
                 }
             }


### PR DESCRIPTION
This would let users determine caching behavior based on more than just `Content-Type`. I am interested in looking at the `PATH_INFO`, but passing `$env` to a code ref seems like the most flexible solution.

Perhaps this should be named something else besides `content_type`, but it seemed simplest to use the existing option.
